### PR TITLE
use "C-unwind" everywhere and remove usage of catch_unwind

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ features = [
 ]
 
 [target.'cfg(target_os = "macos")'.dependencies]
-objc2 = { version = "0.6.3", features = ["catch-all"] }
+objc2 = { version = "0.6.3" }
 objc2-io-surface = { version = "0.3.1" }
 getrandom = "0.2.10"
 libc = "0.2"

--- a/src/backend/app_kit/display_links.rs
+++ b/src/backend/app_kit/display_links.rs
@@ -1,7 +1,6 @@
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::ffi::c_void;
-use std::panic::{self, AssertUnwindSafe};
 use std::ptr::{self, NonNull};
 use std::rc::{Rc, Weak};
 
@@ -53,14 +52,7 @@ extern "C-unwind" fn retain(info: *const c_void) -> *const c_void {
 }
 
 extern "C-unwind" fn release(info: *const c_void) {
-    let result = panic::catch_unwind(AssertUnwindSafe(|| {
-        unsafe { Rc::decrement_strong_count(info as *const DisplayState) };
-    }));
-
-    // If a panic occurs while dropping the Rc<DisplayState>, the only thing left to do is abort.
-    if let Err(_panic) = result {
-        std::process::abort();
-    }
+    unsafe { Rc::decrement_strong_count(info as *const DisplayState) };
 }
 
 extern "C-unwind" fn perform(info: *mut c_void) {
@@ -70,23 +62,17 @@ extern "C-unwind" fn perform(info: *mut c_void) {
         return;
     };
 
-    let result = panic::catch_unwind(AssertUnwindSafe(|| {
-        let windows: Vec<*const View> = event_loop_state.windows.borrow().keys().copied().collect();
-        for ptr in windows {
-            let window_state = event_loop_state.windows.borrow().get(&ptr).cloned();
-            if let Some(window_state) = window_state {
-                if let Some(view) = window_state.view() {
-                    let display = display_from_view(&*view);
-                    if display == Some(state.display_id) {
-                        window_state.handle_event(Event::Frame);
-                    }
+    let windows: Vec<*const View> = event_loop_state.windows.borrow().keys().copied().collect();
+    for ptr in windows {
+        let window_state = event_loop_state.windows.borrow().get(&ptr).cloned();
+        if let Some(window_state) = window_state {
+            if let Some(view) = window_state.view() {
+                let display = display_from_view(&*view);
+                if display == Some(state.display_id) {
+                    window_state.handle_event(Event::Frame);
                 }
             }
         }
-    }));
-
-    if let Err(panic) = result {
-        event_loop_state.propagate_panic(panic);
     }
 }
 

--- a/src/backend/app_kit/event_loop.rs
+++ b/src/backend/app_kit/event_loop.rs
@@ -1,7 +1,5 @@
-use std::any::Any;
 use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
-use std::panic;
 use std::rc::Rc;
 
 use objc2::rc::{autoreleasepool, Retained};
@@ -43,25 +41,12 @@ impl<'a> Drop for RunGuard<'a> {
 
 pub struct EventLoopState {
     pub running: Cell<bool>,
-    pub panic: Cell<Option<Box<dyn Any + Send>>>,
     pub class: &'static AnyClass,
     pub empty_cursor: Retained<NSCursor>,
     pub timers: Timers,
     pub display_links: DisplayLinks,
     pub windows: RefCell<HashMap<*const View, Rc<WindowState>>>,
     pub mtm: MainThreadMarker,
-}
-
-impl EventLoopState {
-    pub(crate) fn propagate_panic(&self, panic: Box<dyn Any + Send + 'static>) {
-        // If we own the event loop, exit and propagate the panic upwards. Otherwise, just abort.
-        if self.running.get() {
-            self.panic.set(Some(panic));
-            self.exit();
-        } else {
-            std::process::abort();
-        }
-    }
 }
 
 impl Drop for EventLoopState {
@@ -89,7 +74,6 @@ impl EventLoopState {
 
             let state = Rc::new(EventLoopState {
                 running: Cell::new(false),
-                panic: Cell::new(None),
                 class,
                 empty_cursor,
                 timers: Timers::new(),
@@ -117,10 +101,6 @@ impl EventLoopState {
 
             let app = NSApplication::sharedApplication(self.mtm);
             app.run();
-
-            if let Some(panic) = self.panic.take() {
-                panic::resume_unwind(panic);
-            }
 
             Ok(())
         })
@@ -154,10 +134,6 @@ impl EventLoopState {
         let _run_guard = RunGuard::new(&self.running)?;
 
         // TODO: poll events
-
-        if let Some(panic) = self.panic.take() {
-            panic::resume_unwind(panic);
-        }
 
         Ok(())
     }

--- a/src/backend/app_kit/timer.rs
+++ b/src/backend/app_kit/timer.rs
@@ -1,7 +1,6 @@
 use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 use std::ffi::c_void;
-use std::panic::{self, AssertUnwindSafe};
 use std::ptr::NonNull;
 use std::rc::Rc;
 use std::time::Duration;
@@ -20,26 +19,13 @@ extern "C-unwind" fn retain(info: *const c_void) -> *const c_void {
 }
 
 extern "C-unwind" fn release(info: *const c_void) {
-    let result = panic::catch_unwind(AssertUnwindSafe(|| {
-        unsafe { Rc::decrement_strong_count(info as *const TimerState) };
-    }));
-
-    // If a panic occurs while dropping the Rc<TimerState>, the only thing left to do is abort.
-    if let Err(_panic) = result {
-        std::process::abort();
-    }
+    unsafe { Rc::decrement_strong_count(info as *const TimerState) };
 }
 
 extern "C-unwind" fn callback(_timer: *mut CFRunLoopTimer, info: *mut c_void) {
     let state = unsafe { &*(info as *mut TimerState) };
 
-    let result = panic::catch_unwind(AssertUnwindSafe(|| {
-        state.handler.borrow_mut()();
-    }));
-
-    if let Err(panic) = result {
-        state.event_loop.state.propagate_panic(panic);
-    }
+    state.handler.borrow_mut()();
 }
 
 pub struct TimerState {

--- a/src/backend/app_kit/window.rs
+++ b/src/backend/app_kit/window.rs
@@ -2,7 +2,6 @@ use std::cell::{Cell, RefCell};
 use std::ffi::c_void;
 use std::ffi::CString;
 use std::ops::{Deref, DerefMut};
-use std::panic::{self, AssertUnwindSafe};
 use std::rc::Rc;
 
 use objc2::declare::ClassBuilder;
@@ -102,73 +101,76 @@ impl View {
         unsafe {
             builder.add_method(
                 sel!(acceptsFirstMouse:),
-                Self::accepts_first_mouse as unsafe extern "C" fn(_, _, _) -> _,
+                Self::accepts_first_mouse as unsafe extern "C-unwind" fn(_, _, _) -> _,
             );
             builder.add_method(
                 sel!(isFlipped),
-                Self::is_flipped as unsafe extern "C" fn(_, _) -> _,
+                Self::is_flipped as unsafe extern "C-unwind" fn(_, _) -> _,
             );
             builder.add_method(
                 sel!(mouseEntered:),
-                Self::mouse_entered as unsafe extern "C" fn(_, _, _),
+                Self::mouse_entered as unsafe extern "C-unwind" fn(_, _, _),
             );
             builder.add_method(
                 sel!(mouseExited:),
-                Self::mouse_exited as unsafe extern "C" fn(_, _, _),
+                Self::mouse_exited as unsafe extern "C-unwind" fn(_, _, _),
             );
             builder.add_method(
                 sel!(mouseMoved:),
-                Self::mouse_moved as unsafe extern "C" fn(_, _, _),
+                Self::mouse_moved as unsafe extern "C-unwind" fn(_, _, _),
             );
             builder.add_method(
                 sel!(mouseDragged:),
-                Self::mouse_moved as unsafe extern "C" fn(_, _, _),
+                Self::mouse_moved as unsafe extern "C-unwind" fn(_, _, _),
             );
             builder.add_method(
                 sel!(rightMouseDragged:),
-                Self::mouse_moved as unsafe extern "C" fn(_, _, _),
+                Self::mouse_moved as unsafe extern "C-unwind" fn(_, _, _),
             );
             builder.add_method(
                 sel!(otherMouseDragged:),
-                Self::mouse_moved as unsafe extern "C" fn(_, _, _),
+                Self::mouse_moved as unsafe extern "C-unwind" fn(_, _, _),
             );
             builder.add_method(
                 sel!(mouseDown:),
-                Self::mouse_down as unsafe extern "C" fn(_, _, _),
+                Self::mouse_down as unsafe extern "C-unwind" fn(_, _, _),
             );
             builder.add_method(
                 sel!(mouseUp:),
-                Self::mouse_up as unsafe extern "C" fn(_, _, _),
+                Self::mouse_up as unsafe extern "C-unwind" fn(_, _, _),
             );
             builder.add_method(
                 sel!(rightMouseDown:),
-                Self::right_mouse_down as unsafe extern "C" fn(_, _, _),
+                Self::right_mouse_down as unsafe extern "C-unwind" fn(_, _, _),
             );
             builder.add_method(
                 sel!(rightMouseUp:),
-                Self::right_mouse_up as unsafe extern "C" fn(_, _, _),
+                Self::right_mouse_up as unsafe extern "C-unwind" fn(_, _, _),
             );
             builder.add_method(
                 sel!(otherMouseDown:),
-                Self::other_mouse_down as unsafe extern "C" fn(_, _, _),
+                Self::other_mouse_down as unsafe extern "C-unwind" fn(_, _, _),
             );
             builder.add_method(
                 sel!(otherMouseUp:),
-                Self::other_mouse_up as unsafe extern "C" fn(_, _, _),
+                Self::other_mouse_up as unsafe extern "C-unwind" fn(_, _, _),
             );
             builder.add_method(
                 sel!(scrollWheel:),
-                Self::scroll_wheel as unsafe extern "C" fn(_, _, _),
+                Self::scroll_wheel as unsafe extern "C-unwind" fn(_, _, _),
             );
             builder.add_method(
                 sel!(cursorUpdate:),
-                Self::cursor_update as unsafe extern "C" fn(_, _, _),
+                Self::cursor_update as unsafe extern "C-unwind" fn(_, _, _),
             );
             builder.add_method(
                 sel!(windowShouldClose:),
-                Self::window_should_close as unsafe extern "C" fn(_, _, _) -> _,
+                Self::window_should_close as unsafe extern "C-unwind" fn(_, _, _) -> _,
             );
-            builder.add_method(sel!(dealloc), View::dealloc as unsafe extern "C" fn(_, _));
+            builder.add_method(
+                sel!(dealloc),
+                View::dealloc as unsafe extern "C-unwind" fn(_, _),
+            );
         }
 
         Ok(builder.register())
@@ -187,177 +189,141 @@ impl View {
         unsafe { &*(self.state_ivar().get() as *const WindowState) }
     }
 
-    fn catch_unwind<F: FnOnce()>(&self, f: F) {
-        let result = panic::catch_unwind(AssertUnwindSafe(f));
-
-        if let Err(panic) = result {
-            self.state().event_loop.state.propagate_panic(panic);
-        }
-    }
-
     pub fn retain(&self) -> Retained<View> {
         unsafe { Retained::retain(self as *const View as *mut View) }.unwrap()
     }
 
-    unsafe extern "C" fn accepts_first_mouse(&self, _: Sel, _event: Option<&NSEvent>) -> Bool {
+    unsafe extern "C-unwind" fn accepts_first_mouse(
+        &self,
+        _: Sel,
+        _event: Option<&NSEvent>,
+    ) -> Bool {
         Bool::YES
     }
 
-    unsafe extern "C" fn is_flipped(&self, _: Sel) -> Bool {
+    unsafe extern "C-unwind" fn is_flipped(&self, _: Sel) -> Bool {
         Bool::YES
     }
 
-    unsafe extern "C" fn mouse_entered(&self, _: Sel, _event: Option<&NSEvent>) {
-        self.catch_unwind(|| {
-            self.state().handle_event(Event::MouseEnter);
-        });
+    unsafe extern "C-unwind" fn mouse_entered(&self, _: Sel, _event: Option<&NSEvent>) {
+        self.state().handle_event(Event::MouseEnter);
     }
 
-    unsafe extern "C" fn mouse_exited(&self, _: Sel, _event: Option<&NSEvent>) {
-        self.catch_unwind(|| {
-            self.state().handle_event(Event::MouseExit);
-        });
+    unsafe extern "C-unwind" fn mouse_exited(&self, _: Sel, _event: Option<&NSEvent>) {
+        self.state().handle_event(Event::MouseExit);
     }
 
-    unsafe extern "C" fn mouse_moved(&self, _: Sel, event: Option<&NSEvent>) {
-        self.catch_unwind(|| {
-            let Some(event) = event else {
-                return;
-            };
+    unsafe extern "C-unwind" fn mouse_moved(&self, _: Sel, event: Option<&NSEvent>) {
+        let Some(event) = event else {
+            return;
+        };
 
-            let point = self.convertPoint_fromView(event.locationInWindow(), None);
-            self.state().handle_event(Event::MouseMove(Point {
-                x: point.x,
-                y: point.y,
-            }));
-        });
+        let point = self.convertPoint_fromView(event.locationInWindow(), None);
+        self.state().handle_event(Event::MouseMove(Point {
+            x: point.x,
+            y: point.y,
+        }));
     }
 
-    unsafe extern "C" fn mouse_down(&self, _: Sel, event: Option<&NSEvent>) {
-        self.catch_unwind(|| {
-            let result = self.state().handle_event(Event::MouseDown(MouseButton::Left));
+    unsafe extern "C-unwind" fn mouse_down(&self, _: Sel, event: Option<&NSEvent>) {
+        let result = self.state().handle_event(Event::MouseDown(MouseButton::Left));
 
-            if result != Some(Response::Capture) {
-                let () = msg_send![super(self, NSView::class()), mouseDown: event];
-            }
-        });
+        if result != Some(Response::Capture) {
+            let () = msg_send![super(self, NSView::class()), mouseDown: event];
+        }
     }
 
-    unsafe extern "C" fn mouse_up(&self, _: Sel, event: Option<&NSEvent>) {
-        self.catch_unwind(|| {
-            let result = self.state().handle_event(Event::MouseUp(MouseButton::Left));
+    unsafe extern "C-unwind" fn mouse_up(&self, _: Sel, event: Option<&NSEvent>) {
+        let result = self.state().handle_event(Event::MouseUp(MouseButton::Left));
 
-            if result != Some(Response::Capture) {
-                let () = msg_send![super(self, NSView::class()), mouseUp: event];
-            }
-        });
+        if result != Some(Response::Capture) {
+            let () = msg_send![super(self, NSView::class()), mouseUp: event];
+        }
     }
 
-    unsafe extern "C" fn right_mouse_down(&self, _: Sel, event: Option<&NSEvent>) {
-        self.catch_unwind(|| {
-            let result = self.state().handle_event(Event::MouseDown(MouseButton::Right));
+    unsafe extern "C-unwind" fn right_mouse_down(&self, _: Sel, event: Option<&NSEvent>) {
+        let result = self.state().handle_event(Event::MouseDown(MouseButton::Right));
 
-            if result != Some(Response::Capture) {
-                let () = msg_send![super(self, NSView::class()), rightMouseDown: event];
-            }
-        });
+        if result != Some(Response::Capture) {
+            let () = msg_send![super(self, NSView::class()), rightMouseDown: event];
+        }
     }
 
-    unsafe extern "C" fn right_mouse_up(&self, _: Sel, event: Option<&NSEvent>) {
-        self.catch_unwind(|| {
-            let result = self.state().handle_event(Event::MouseUp(MouseButton::Right));
+    unsafe extern "C-unwind" fn right_mouse_up(&self, _: Sel, event: Option<&NSEvent>) {
+        let result = self.state().handle_event(Event::MouseUp(MouseButton::Right));
 
-            if result != Some(Response::Capture) {
-                let () = msg_send![super(self, NSView::class()), rightMouseUp: event];
-            }
-        });
+        if result != Some(Response::Capture) {
+            let () = msg_send![super(self, NSView::class()), rightMouseUp: event];
+        }
     }
 
-    unsafe extern "C" fn other_mouse_down(&self, _: Sel, event: Option<&NSEvent>) {
-        self.catch_unwind(|| {
-            let Some(event) = event else {
-                return;
-            };
+    unsafe extern "C-unwind" fn other_mouse_down(&self, _: Sel, event: Option<&NSEvent>) {
+        let Some(event) = event else {
+            return;
+        };
 
-            let button_number = event.buttonNumber();
-            let result = if let Some(button) = mouse_button_from_number(button_number) {
-                self.state().handle_event(Event::MouseDown(button))
-            } else {
-                None
-            };
+        let button_number = event.buttonNumber();
+        let result = if let Some(button) = mouse_button_from_number(button_number) {
+            self.state().handle_event(Event::MouseDown(button))
+        } else {
+            None
+        };
 
-            if result != Some(Response::Capture) {
-                let () = msg_send![super(self, NSView::class()), otherMouseDown: event];
-            }
-        });
+        if result != Some(Response::Capture) {
+            let () = msg_send![super(self, NSView::class()), otherMouseDown: event];
+        }
     }
 
-    unsafe extern "C" fn other_mouse_up(&self, _: Sel, event: Option<&NSEvent>) {
-        self.catch_unwind(|| {
-            let Some(event) = event else {
-                return;
-            };
+    unsafe extern "C-unwind" fn other_mouse_up(&self, _: Sel, event: Option<&NSEvent>) {
+        let Some(event) = event else {
+            return;
+        };
 
-            let button_number = event.buttonNumber();
-            let result = if let Some(button) = mouse_button_from_number(button_number) {
-                self.state().handle_event(Event::MouseUp(button))
-            } else {
-                None
-            };
+        let button_number = event.buttonNumber();
+        let result = if let Some(button) = mouse_button_from_number(button_number) {
+            self.state().handle_event(Event::MouseUp(button))
+        } else {
+            None
+        };
 
-            if result != Some(Response::Capture) {
-                let () = msg_send![super(self, NSView::class()), otherMouseUp: event];
-            }
-        });
+        if result != Some(Response::Capture) {
+            let () = msg_send![super(self, NSView::class()), otherMouseUp: event];
+        }
     }
 
-    unsafe extern "C" fn scroll_wheel(&self, _: Sel, event: Option<&NSEvent>) {
-        self.catch_unwind(|| {
-            let Some(event) = event else {
-                return;
-            };
+    unsafe extern "C-unwind" fn scroll_wheel(&self, _: Sel, event: Option<&NSEvent>) {
+        let Some(event) = event else {
+            return;
+        };
 
-            let dx = event.scrollingDeltaX();
-            let dy = event.scrollingDeltaY();
-            let delta = if event.hasPreciseScrollingDeltas() {
-                Point::new(dx, dy)
-            } else {
-                Point::new(32.0 * dx, 32.0 * dy)
-            };
-            let result = self.state().handle_event(Event::Scroll(delta));
+        let dx = event.scrollingDeltaX();
+        let dy = event.scrollingDeltaY();
+        let delta = if event.hasPreciseScrollingDeltas() {
+            Point::new(dx, dy)
+        } else {
+            Point::new(32.0 * dx, 32.0 * dy)
+        };
+        let result = self.state().handle_event(Event::Scroll(delta));
 
-            if result != Some(Response::Capture) {
-                let () = msg_send![super(self, NSView::class()), scrollWheel: event];
-            }
-        });
+        if result != Some(Response::Capture) {
+            let () = msg_send![super(self, NSView::class()), scrollWheel: event];
+        }
     }
 
-    unsafe extern "C" fn cursor_update(&self, _: Sel, _event: Option<&NSEvent>) {
-        self.catch_unwind(|| {
-            self.state().update_cursor();
-        });
+    unsafe extern "C-unwind" fn cursor_update(&self, _: Sel, _event: Option<&NSEvent>) {
+        self.state().update_cursor();
     }
 
-    unsafe extern "C" fn window_should_close(&self, _: Sel, _sender: &NSWindow) -> Bool {
-        self.catch_unwind(|| {
-            self.state().handle_event(Event::Close);
-        });
+    unsafe extern "C-unwind" fn window_should_close(&self, _: Sel, _sender: &NSWindow) -> Bool {
+        self.state().handle_event(Event::Close);
 
         Bool::NO
     }
 
-    unsafe extern "C" fn dealloc(this: *mut Self, _: Sel) {
-        let result = panic::catch_unwind(AssertUnwindSafe(|| {
-            drop(Rc::from_raw(
-                (*this).state_ivar().get() as *const WindowState
-            ));
-        }));
-
-        // If a panic occurs while dropping the Rc<WindowState>, the only thing left to do is
-        // abort.
-        if let Err(_panic) = result {
-            std::process::abort();
-        }
+    unsafe extern "C-unwind" fn dealloc(this: *mut Self, _: Sel) {
+        drop(Rc::from_raw(
+            (*this).state_ivar().get() as *const WindowState
+        ));
 
         let () = msg_send![super(this, NSView::class()), dealloc];
     }

--- a/src/backend/win32/event_loop.rs
+++ b/src/backend/win32/event_loop.rs
@@ -1,7 +1,5 @@
-use std::any::Any;
 use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
-use std::panic::{self, AssertUnwindSafe};
 use std::rc::{Rc, Weak};
 use std::{mem, ptr};
 
@@ -69,7 +67,7 @@ pub unsafe extern "system" fn message_wnd_proc(
         return DefWindowProcW(hwnd, msg, wparam, lparam);
     };
 
-    let result = panic::catch_unwind(AssertUnwindSafe(|| match msg {
+    match msg {
         msg::WM_TIMER => {
             event_loop_state.timers.handle_timer(wparam.0);
         }
@@ -83,15 +81,6 @@ pub unsafe extern "system" fn message_wnd_proc(
             drop(Rc::from_raw(event_loop_state_ptr));
         }
         _ => {}
-    }));
-
-    if let Err(panic) = result {
-        event_loop_state.propagate_panic(panic);
-    }
-
-    // If a panic occurs while dropping the Rc<EventLoopState>, the only thing left to do is abort.
-    if let Err(_panic) = panic::catch_unwind(AssertUnwindSafe(move || drop(event_loop_state))) {
-        std::process::abort();
     }
 
     DefWindowProcW(hwnd, msg, wparam, lparam)
@@ -121,7 +110,6 @@ impl<'a> Drop for RunGuard<'a> {
 
 pub struct EventLoopState {
     pub running: Cell<bool>,
-    pub panic: Cell<Option<Box<dyn Any + Send>>>,
     pub message_class: PCWSTR,
     pub message_hwnd: HWND,
     pub window_class: PCWSTR,
@@ -129,18 +117,6 @@ pub struct EventLoopState {
     pub timers: Timers,
     pub vsync_threads: VsyncThreads,
     pub windows: RefCell<HashMap<isize, Rc<WindowState>>>,
-}
-
-impl EventLoopState {
-    pub(crate) fn propagate_panic(&self, panic: Box<dyn Any + Send + 'static>) {
-        // If we own the event loop, exit and propagate the panic upwards. Otherwise, just abort.
-        if self.running.get() {
-            self.panic.set(Some(panic));
-            unsafe { PostQuitMessage(0) };
-        } else {
-            std::process::abort();
-        }
-    }
 }
 
 impl Drop for EventLoopState {
@@ -193,7 +169,6 @@ impl EventLoopState {
 
         let state = Rc::new(EventLoopState {
             running: Cell::new(false),
-            panic: Cell::new(None),
             message_class,
             message_hwnd,
             window_class,
@@ -233,10 +208,6 @@ impl EventLoopState {
             }
         };
 
-        if let Some(panic) = self.panic.take() {
-            panic::resume_unwind(panic);
-        }
-
         result
     }
 
@@ -265,10 +236,6 @@ impl EventLoopState {
                 TranslateMessage(&msg);
                 DispatchMessageW(&msg);
             }
-        }
-
-        if let Some(panic) = self.panic.take() {
-            panic::resume_unwind(panic);
         }
 
         Ok(())

--- a/src/backend/win32/window.rs
+++ b/src/backend/win32/window.rs
@@ -2,7 +2,6 @@ use std::alloc::{alloc, dealloc, Layout};
 use std::cell::{Cell, RefCell};
 use std::ffi::{c_int, c_void};
 use std::mem::MaybeUninit;
-use std::panic::{self, AssertUnwindSafe};
 use std::rc::Rc;
 use std::{mem, ptr, slice};
 
@@ -111,184 +110,163 @@ pub unsafe extern "system" fn wnd_proc(
 
     let state = WindowState::from_raw(state_ptr);
 
-    let result = panic::catch_unwind(AssertUnwindSafe(|| {
-        match msg {
-            msg::WM_SETCURSOR => {
-                if LOWORD(lparam.0 as u32) == msg::HTCLIENT as u16 {
-                    state.update_cursor();
-                    return Some(LRESULT(1));
-                }
+    match msg {
+        msg::WM_SETCURSOR => {
+            if LOWORD(lparam.0 as u32) == msg::HTCLIENT as u16 {
+                state.update_cursor();
+                return LRESULT(1);
             }
-            msg::WM_ERASEBKGND => {
-                return Some(LRESULT(1));
-            }
-            msg::WM_PAINT => {
-                let mut rects = Vec::new();
+        }
+        msg::WM_ERASEBKGND => {
+            return LRESULT(1);
+        }
+        msg::WM_PAINT => {
+            let mut rects = Vec::new();
 
-                let rgn = gdi::CreateRectRgn(0, 0, 0, 0);
-                gdi::GetUpdateRgn(hwnd, rgn, false);
-                let size = gdi::GetRegionData(rgn, 0, None);
-                if size != 0 {
-                    let align = mem::align_of::<gdi::RGNDATA>();
-                    let layout = Layout::from_size_align(size as usize, align).unwrap();
-                    let ptr = alloc(layout) as *mut gdi::RGNDATA;
+            let rgn = gdi::CreateRectRgn(0, 0, 0, 0);
+            gdi::GetUpdateRgn(hwnd, rgn, false);
+            let size = gdi::GetRegionData(rgn, 0, None);
+            if size != 0 {
+                let align = mem::align_of::<gdi::RGNDATA>();
+                let layout = Layout::from_size_align(size as usize, align).unwrap();
+                let ptr = alloc(layout) as *mut gdi::RGNDATA;
 
-                    let result = gdi::GetRegionData(rgn, size, Some(ptr));
-                    if result == size {
-                        let count = (*ptr).rdh.nCount as usize;
+                let result = gdi::GetRegionData(rgn, size, Some(ptr));
+                if result == size {
+                    let count = (*ptr).rdh.nCount as usize;
 
-                        let buffer_ptr = ptr::addr_of!((*ptr).Buffer) as *const RECT;
-                        let buffer = slice::from_raw_parts(buffer_ptr, count);
+                    let buffer_ptr = ptr::addr_of!((*ptr).Buffer) as *const RECT;
+                    let buffer = slice::from_raw_parts(buffer_ptr, count);
 
-                        rects.reserve_exact(count);
-                        for rect in buffer {
-                            rects.push(Rect {
-                                x: rect.left as f64,
-                                y: rect.top as f64,
-                                width: (rect.right - rect.left) as f64,
-                                height: (rect.bottom - rect.top) as f64,
-                            });
-                        }
+                    rects.reserve_exact(count);
+                    for rect in buffer {
+                        rects.push(Rect {
+                            x: rect.left as f64,
+                            y: rect.top as f64,
+                            width: (rect.right - rect.left) as f64,
+                            height: (rect.bottom - rect.top) as f64,
+                        });
                     }
-
-                    dealloc(ptr as *mut u8, layout);
-                }
-                gdi::DeleteObject(rgn);
-
-                // Only validate the dirty region if we successfully invoked the event handler.
-                if state.handle_event(Event::Expose(&rects)).is_some() {
-                    gdi::ValidateRgn(hwnd, gdi::HRGN(0));
                 }
 
-                return Some(LRESULT(0));
+                dealloc(ptr as *mut u8, layout);
             }
-            msg::WM_MOUSEMOVE => {
-                if !state.mouse_in_window.get() {
-                    state.mouse_in_window.set(true);
-                    state.handle_event(Event::MouseEnter);
+            gdi::DeleteObject(rgn);
 
-                    let _ = TrackMouseEvent(&mut TRACKMOUSEEVENT {
-                        cbSize: mem::size_of::<TRACKMOUSEEVENT>() as u32,
-                        dwFlags: TME_LEAVE,
-                        hwndTrack: hwnd,
-                        dwHoverTime: HOVER_DEFAULT,
-                    });
-                }
-
-                let point_physical = Point {
-                    x: GET_X_LPARAM(lparam) as f64,
-                    y: GET_Y_LPARAM(lparam) as f64,
-                };
-                let point = point_physical.scale(state.scale().recip());
-
-                state.handle_event(Event::MouseMove(point));
-
-                return Some(LRESULT(0));
+            // Only validate the dirty region if we successfully invoked the event handler.
+            if state.handle_event(Event::Expose(&rects)).is_some() {
+                gdi::ValidateRgn(hwnd, gdi::HRGN(0));
             }
-            WM_MOUSELEAVE => {
-                state.mouse_in_window.set(false);
-                state.handle_event(Event::MouseExit);
+
+            return LRESULT(0);
+        }
+        msg::WM_MOUSEMOVE => {
+            if !state.mouse_in_window.get() {
+                state.mouse_in_window.set(true);
+                state.handle_event(Event::MouseEnter);
+
+                let _ = TrackMouseEvent(&mut TRACKMOUSEEVENT {
+                    cbSize: mem::size_of::<TRACKMOUSEEVENT>() as u32,
+                    dwFlags: TME_LEAVE,
+                    hwndTrack: hwnd,
+                    dwHoverTime: HOVER_DEFAULT,
+                });
             }
-            msg::WM_LBUTTONDOWN
-            | msg::WM_LBUTTONUP
-            | msg::WM_MBUTTONDOWN
-            | msg::WM_MBUTTONUP
-            | msg::WM_RBUTTONDOWN
-            | msg::WM_RBUTTONUP
-            | msg::WM_XBUTTONDOWN
-            | msg::WM_XBUTTONUP => {
-                let button = match msg {
-                    msg::WM_LBUTTONDOWN | msg::WM_LBUTTONUP => Some(MouseButton::Left),
-                    msg::WM_MBUTTONDOWN | msg::WM_MBUTTONUP => Some(MouseButton::Middle),
-                    msg::WM_RBUTTONDOWN | msg::WM_RBUTTONUP => Some(MouseButton::Right),
-                    msg::WM_XBUTTONDOWN | msg::WM_XBUTTONUP => match GET_XBUTTON_WPARAM(wparam) {
-                        msg::XBUTTON1 => Some(MouseButton::Back),
-                        msg::XBUTTON2 => Some(MouseButton::Forward),
-                        _ => None,
-                    },
+
+            let point_physical = Point {
+                x: GET_X_LPARAM(lparam) as f64,
+                y: GET_Y_LPARAM(lparam) as f64,
+            };
+            let point = point_physical.scale(state.scale().recip());
+
+            state.handle_event(Event::MouseMove(point));
+
+            return LRESULT(0);
+        }
+        WM_MOUSELEAVE => {
+            state.mouse_in_window.set(false);
+            state.handle_event(Event::MouseExit);
+        }
+        msg::WM_LBUTTONDOWN
+        | msg::WM_LBUTTONUP
+        | msg::WM_MBUTTONDOWN
+        | msg::WM_MBUTTONUP
+        | msg::WM_RBUTTONDOWN
+        | msg::WM_RBUTTONUP
+        | msg::WM_XBUTTONDOWN
+        | msg::WM_XBUTTONUP => {
+            let button = match msg {
+                msg::WM_LBUTTONDOWN | msg::WM_LBUTTONUP => Some(MouseButton::Left),
+                msg::WM_MBUTTONDOWN | msg::WM_MBUTTONUP => Some(MouseButton::Middle),
+                msg::WM_RBUTTONDOWN | msg::WM_RBUTTONUP => Some(MouseButton::Right),
+                msg::WM_XBUTTONDOWN | msg::WM_XBUTTONUP => match GET_XBUTTON_WPARAM(wparam) {
+                    msg::XBUTTON1 => Some(MouseButton::Back),
+                    msg::XBUTTON2 => Some(MouseButton::Forward),
+                    _ => None,
+                },
+                _ => None,
+            };
+
+            if let Some(button) = button {
+                let event = match msg {
+                    msg::WM_LBUTTONDOWN
+                    | msg::WM_MBUTTONDOWN
+                    | msg::WM_RBUTTONDOWN
+                    | msg::WM_XBUTTONDOWN => Some(Event::MouseDown(button)),
+                    msg::WM_LBUTTONUP
+                    | msg::WM_MBUTTONUP
+                    | msg::WM_RBUTTONUP
+                    | msg::WM_XBUTTONUP => Some(Event::MouseUp(button)),
                     _ => None,
                 };
 
-                if let Some(button) = button {
-                    let event = match msg {
-                        msg::WM_LBUTTONDOWN
-                        | msg::WM_MBUTTONDOWN
-                        | msg::WM_RBUTTONDOWN
-                        | msg::WM_XBUTTONDOWN => Some(Event::MouseDown(button)),
-                        msg::WM_LBUTTONUP
-                        | msg::WM_MBUTTONUP
-                        | msg::WM_RBUTTONUP
-                        | msg::WM_XBUTTONUP => Some(Event::MouseUp(button)),
-                        _ => None,
-                    };
-
-                    if let Some(event) = event {
-                        match event {
-                            Event::MouseDown(_) => {
-                                state.mouse_down_count.set(state.mouse_down_count.get() + 1);
-                                if state.mouse_down_count.get() == 1 {
-                                    SetCapture(hwnd);
-                                }
+                if let Some(event) = event {
+                    match event {
+                        Event::MouseDown(_) => {
+                            state.mouse_down_count.set(state.mouse_down_count.get() + 1);
+                            if state.mouse_down_count.get() == 1 {
+                                SetCapture(hwnd);
                             }
-                            Event::MouseUp(_) => {
-                                state.mouse_down_count.set(state.mouse_down_count.get() - 1);
-                                if state.mouse_down_count.get() == 0 {
-                                    let _ = ReleaseCapture();
-                                }
+                        }
+                        Event::MouseUp(_) => {
+                            state.mouse_down_count.set(state.mouse_down_count.get() - 1);
+                            if state.mouse_down_count.get() == 0 {
+                                let _ = ReleaseCapture();
                             }
-                            _ => {}
                         }
+                        _ => {}
+                    }
 
-                        if state.handle_event(event) == Some(Response::Capture) {
-                            return Some(LRESULT(0));
-                        }
+                    if state.handle_event(event) == Some(Response::Capture) {
+                        return LRESULT(0);
                     }
                 }
             }
-            msg::WM_MOUSEWHEEL | msg::WM_MOUSEHWHEEL => {
-                let delta = GET_WHEEL_DELTA_WPARAM(wparam) as f64 / WHEEL_DELTA as f64;
-                let point = match msg {
-                    msg::WM_MOUSEWHEEL => Point::new(0.0, delta),
-                    msg::WM_MOUSEHWHEEL => Point::new(delta, 0.0),
-                    _ => unreachable!(),
-                };
-
-                if state.handle_event(Event::Scroll(point)) == Some(Response::Capture) {
-                    return Some(LRESULT(0));
-                }
-            }
-            msg::WM_CLOSE => {
-                state.handle_event(Event::Close);
-                return Some(LRESULT(0));
-            }
-            msg::WM_DESTROY => {
-                SetWindowLongPtrW(hwnd, msg::GWLP_USERDATA, 0);
-                drop(Rc::from_raw(state_ptr));
-            }
-            _ => {}
         }
+        msg::WM_MOUSEWHEEL | msg::WM_MOUSEHWHEEL => {
+            let delta = GET_WHEEL_DELTA_WPARAM(wparam) as f64 / WHEEL_DELTA as f64;
+            let point = match msg {
+                msg::WM_MOUSEWHEEL => Point::new(0.0, delta),
+                msg::WM_MOUSEHWHEEL => Point::new(delta, 0.0),
+                _ => unreachable!(),
+            };
 
-        None
-    }));
-
-    let return_value = match result {
-        Ok(return_value) => return_value,
-        Err(panic) => {
-            state.event_loop.state.propagate_panic(panic);
-            None
+            if state.handle_event(Event::Scroll(point)) == Some(Response::Capture) {
+                return LRESULT(0);
+            }
         }
-    };
-
-    // If a panic occurs while dropping the Rc<WindowState>, the only thing left to do is abort.
-    if let Err(_panic) = panic::catch_unwind(AssertUnwindSafe(move || drop(state))) {
-        std::process::abort();
+        msg::WM_CLOSE => {
+            state.handle_event(Event::Close);
+            return LRESULT(0);
+        }
+        msg::WM_DESTROY => {
+            SetWindowLongPtrW(hwnd, msg::GWLP_USERDATA, 0);
+            drop(Rc::from_raw(state_ptr));
+        }
+        _ => {}
     }
 
-    if let Some(return_value) = return_value {
-        return_value
-    } else {
-        DefWindowProcW(hwnd, msg, wparam, lparam)
-    }
+    DefWindowProcW(hwnd, msg, wparam, lparam)
 }
 
 pub struct WindowState {


### PR DESCRIPTION
[Rust 1.71.0](https://blog.rust-lang.org/2023/07/13/Rust-1.71.0/#c-unwind-abi) stabilized the `"C-unwind"` ABI. As of [`objc2` version 0.6.0](https://github.com/madsmtm/objc2/blob/0fa974523cdec3856be95d3655957fd77cf11843/crates/objc2/CHANGELOG.md#060---2025-01-22), `"C-unwind"` is used for all message send calls, which means that we can safely stop using the `catch-all` feature. It is also now possible to use `"C-unwind"` for Objective-C method definitions, which means that we can safely remove all the `catch_unwind` machinery in the AppKit backend.

As of [Rust 1.81.0](https://blog.rust-lang.org/2024/09/05/Rust-1.81.0/#abort-on-uncaught-panics-in-extern-c-functions), it is now sound to panic inside an `extern "C"` function, as uncaught panics will be turned into aborts. This means that we can safely remove all of the `catch_unwind` machinery in the Win32 backend as well.